### PR TITLE
Add emerald splash

### DIFF
--- a/src/main/java/mrsterner/phantomblood/PhantomBlood.java
+++ b/src/main/java/mrsterner/phantomblood/PhantomBlood.java
@@ -7,6 +7,7 @@ import mrsterner.phantomblood.common.callback.CommandCallback;
 import mrsterner.phantomblood.common.callback.StandCallback;
 import mrsterner.phantomblood.common.StandPunchHandler;
 import mrsterner.phantomblood.common.callback.VampireCallback;
+import mrsterner.phantomblood.common.entity.EmeraldSplashEntity;
 import mrsterner.phantomblood.common.entity.KillerVirusCloudEntity;
 import mrsterner.phantomblood.common.entity.KillerVirusEntity;
 import mrsterner.phantomblood.common.hamon.HamonUserComponent;
@@ -61,6 +62,9 @@ public final class PhantomBlood implements ModInitializer, EntityComponentInitia
             FabricEntityTypeBuilder.<KillerVirusCloudEntity>create(SpawnGroup.MISC, KillerVirusCloudEntity::new)
                     .dimensions(EntityDimensions.fixed(0.25F, 0.25F)).trackRangeBlocks(4).trackedUpdateRate(10).build()
     );
+    public static final EntityType<EmeraldSplashEntity> EMERALD_SPLASH_ENTITY_TYPE = Registry.register(Registry.ENTITY_TYPE, new Identifier(PhantomBlood.MODID, "emerald_splash"),
+            FabricEntityTypeBuilder.<EmeraldSplashEntity>create(SpawnGroup.MISC, EmeraldSplashEntity::new)
+    .dimensions(EntityDimensions.fixed(0.25f, 0.25f)).trackRangeBlocks(64).trackedUpdateRate(10).build());
 
     @Override
     public void onInitialize() {

--- a/src/main/java/mrsterner/phantomblood/PhantomBloodClient.java
+++ b/src/main/java/mrsterner/phantomblood/PhantomBloodClient.java
@@ -89,6 +89,7 @@ public class PhantomBloodClient implements ClientModInitializer {
 
         EntityRendererRegistry.INSTANCE.register(PhantomBlood.KillerVirusEntityType, (dispatcher, context) -> new FlyingItemEntityRenderer(dispatcher, context.getItemRenderer()));receiveEntityPacket();
         EntityRendererRegistry.INSTANCE.register(PhantomBlood.KillerVirusCloudEntityType, (dispatcher, context) -> new FlyingItemEntityRenderer(dispatcher, context.getItemRenderer()));receiveEntityPacket();
+        EntityRendererRegistry.INSTANCE.register(PhantomBlood.EMERALD_SPLASH_ENTITY_TYPE, (dispatcher, context) -> new FlyingItemEntityRenderer(dispatcher, context.getItemRenderer()));
 
 
         Registry.ITEM.forEach((item) -> {

--- a/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
+++ b/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
@@ -40,15 +40,16 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
         this.pickupType = PickupPermission.DISALLOWED;
         this.target = target;
         setNoGravity(true);
+        setPos(getX()+world.random.nextGaussian(), getY()+world.random.nextDouble(), getZ()+world.random.nextGaussian());
     }
 
     @Override
     public void tick() {
         super.tick();
         if (target != null && target.isAlive()) {
-            if (!inGround) {
+            if (!inGround && age > 10) {
                 Vec3d vel = getVelocity();
-                Vec3d dir = target.getPos().subtract(getPos()).normalize().multiply(0.2);
+                Vec3d dir = new Vec3d(target.getX(), target.getEyeY(), target.getZ()).subtract(getPos()).normalize().multiply(0.2+world.random.nextGaussian()*0.05);
                 if (Math.acos(vel.dotProduct(dir)/(vel.length()*dir.length())) > 0.3) {
                     setVelocity(getVelocity().multiply(0.85));
                 }

--- a/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
+++ b/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
@@ -116,6 +116,18 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
         return SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP;
     }
 
+    /**
+     * Gets a target for an emerald splash projectile entity.
+     *
+     * <p>There is a 50-50 chance that this method will go for the player target, or for a random nearby target. If there
+     * are no nearby targets, it will always pick the player target. If there is no player target either, it returns null.</p>
+     *
+     * @param random a random instance
+     * @param nearbyPotentialTargets a list of nearby potential target entities
+     * @param playerTarget the player's target, or null
+     *
+     * @return a target, or null if there are no options
+     */
     public static @Nullable Entity getTarget(Random random, List<Entity> nearbyPotentialTargets, @Nullable Entity playerTarget) {
         Entity target = null;
 
@@ -130,6 +142,13 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
         return target;
     }
 
+    /**
+     * Gets the target entity of an entity.
+     *
+     * @param entity the entity whose target we want
+     *
+     * @return the entity's current combat target, or null
+     */
     public static @Nullable Entity getTargetOf(LivingEntity entity) {
         final Entity target = entity.getAttacking();
         if (target == null) {
@@ -139,23 +158,47 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
         return target;
     }
 
+
+    /**
+     * Gets a list of potential targets (as specified by {@link EmeraldSplashEntity#isValidTarget(Entity, Entity)})
+     * within 20 blocks of an entity.
+     *
+     * @param world the world
+     * @param owner the owner of the projectile
+     * @param lookFrom the entity at the centre of the search radius
+     *
+     * @return a list of potential target entities
+     */
     public static List<Entity> findNearbyPotentialTargets(World world, Entity owner, Entity lookFrom) {
         return world.getOtherEntities(owner, lookFrom.getBoundingBox().expand(20.0), entity -> isValidTarget(entity, owner));
     }
 
+    /**
+     * Whether an entity is a valid target. Valid targets are:
+     *
+     * <ul>
+     *  <li>alive</li>
+     *  <li>not our owner</li>
+     *  <li>not on the same team as our owner</li>
+     *  <li>monsters, players, or angered neutral mobs</li>
+     * </ul>
+     *
+     * @param entity the entity to check
+     * @param owner the projectile's owner
+     *
+     * @return true if the entity is a valid target, false otherwise
+     */
     private static boolean isValidTarget(Entity entity, Entity owner) {
         if (!entity.isAlive()) {
             return false;
         }
 
-        if (entity instanceof Monster) {
-            return true;
+        if (entity == owner || entity.isTeammate(owner)) {
+            return false;
         }
 
-        if ((entity instanceof Angerable && ((Angerable) entity).hasAngerTime()) || entity instanceof PlayerEntity) {
-            return !entity.isTeammate(owner) && entity != owner;
-        }
-
-        return false;
+        return entity instanceof Monster
+                || (entity instanceof Angerable && ((Angerable) entity).hasAngerTime())
+                || entity instanceof PlayerEntity;
     }
 }

--- a/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
+++ b/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
@@ -1,0 +1,60 @@
+package mrsterner.phantomblood.common.entity;
+
+import mrsterner.phantomblood.PhantomBlood;
+import mrsterner.phantomblood.PhantomBloodClient;
+import mrsterner.phantomblood.client.EntitySpawnPacket;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.api.EnvironmentInterface;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.FlyingItemEntity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.data.DataTracker;
+import net.minecraft.entity.data.TrackedData;
+import net.minecraft.entity.data.TrackedDataHandlerRegistry;
+import net.minecraft.entity.projectile.PersistentProjectileEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.network.Packet;
+import net.minecraft.world.World;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@EnvironmentInterface(value = EnvType.CLIENT, itf = FlyingItemEntity.class)
+public class EmeraldSplashEntity extends PersistentProjectileEntity implements FlyingItemEntity {
+    private static final TrackedData<Optional<UUID>> TARGET = DataTracker.registerData(EmeraldSplashEntity.class, TrackedDataHandlerRegistry.OPTIONAL_UUID);
+
+    public EmeraldSplashEntity(EntityType<? extends EmeraldSplashEntity> entityType, World world) {
+        super(entityType, world);
+    }
+
+    public EmeraldSplashEntity(LivingEntity owner, Entity target, World world) {
+        super(PhantomBlood.EMERALD_SPLASH_ENTITY_TYPE, owner, world);
+        dataTracker.set(TARGET, Optional.of(target.getUuid()));
+        this.pickupType = PickupPermission.DISALLOWED;
+    }
+
+    @Override
+    protected void initDataTracker() {
+        super.initDataTracker();
+        dataTracker.startTracking(TARGET, Optional.empty());
+    }
+
+    @Override
+    protected ItemStack asItemStack() {
+        return ItemStack.EMPTY;
+    }
+
+    @Override
+    public Packet<?> createSpawnPacket() {
+        return EntitySpawnPacket.create(this, PhantomBloodClient.PacketID);
+    }
+
+    @Override
+    @Environment(EnvType.CLIENT)
+    public ItemStack getStack() {
+        return Items.EMERALD.getDefaultStack();
+    }
+}

--- a/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
+++ b/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
@@ -17,6 +17,7 @@ import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.Packet;
+import net.minecraft.particle.DustParticleEffect;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
@@ -55,6 +56,9 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
                 }
                 setVelocity(getVelocity().add(dir));
             }
+        }
+        if (world.isClient) {
+            world.addParticle(new DustParticleEffect(0.0f, 1.0f, 0.0f, 1.0f), getX(), getY(), getZ(), 0.0, 0.0, 0.0);
         }
     }
 

--- a/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
+++ b/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
@@ -17,23 +17,44 @@ import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.Packet;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.UUID;
 
 @EnvironmentInterface(value = EnvType.CLIENT, itf = FlyingItemEntity.class)
 public class EmeraldSplashEntity extends PersistentProjectileEntity implements FlyingItemEntity {
     private static final TrackedData<Optional<UUID>> TARGET = DataTracker.registerData(EmeraldSplashEntity.class, TrackedDataHandlerRegistry.OPTIONAL_UUID);
+    private @Nullable Entity target;
 
     public EmeraldSplashEntity(EntityType<? extends EmeraldSplashEntity> entityType, World world) {
         super(entityType, world);
+        setNoGravity(true);
     }
 
     public EmeraldSplashEntity(LivingEntity owner, Entity target, World world) {
         super(PhantomBlood.EMERALD_SPLASH_ENTITY_TYPE, owner, world);
         dataTracker.set(TARGET, Optional.of(target.getUuid()));
         this.pickupType = PickupPermission.DISALLOWED;
+        this.target = target;
+        setNoGravity(true);
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        if (target != null && target.isAlive()) {
+            if (!inGround) {
+                Vec3d vel = getVelocity();
+                Vec3d dir = target.getPos().subtract(getPos()).normalize().multiply(0.2);
+                if (Math.acos(vel.dotProduct(dir)/(vel.length()*dir.length())) > 0.3) {
+                    setVelocity(getVelocity().multiply(0.85));
+                }
+                setVelocity(getVelocity().add(dir));
+            }
+        }
     }
 
     @Override

--- a/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
+++ b/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
@@ -50,7 +50,7 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
         if (target != null && target.isAlive()) {
             if (!inGround && age > 10) {
                 Vec3d vel = getVelocity();
-                Vec3d dir = new Vec3d(target.getX(), target.getEyeY(), target.getZ()).subtract(getPos()).normalize().multiply(0.2+world.random.nextGaussian()*0.05);
+                Vec3d dir = new Vec3d(target.getX(), target.getRandomBodyY(), target.getZ()).subtract(getPos()).normalize().multiply(0.2+world.random.nextGaussian()*0.05);
                 if (Math.acos(vel.dotProduct(dir)/(vel.length()*dir.length())) > 0.3) {
                     setVelocity(getVelocity().multiply(0.85));
                 }
@@ -59,6 +59,8 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
         }
         if (world.isClient) {
             world.addParticle(new DustParticleEffect(0.0f, 1.0f, 0.0f, 1.0f), getX(), getY(), getZ(), 0.0, 0.0, 0.0);
+        } else if (inGround || target == null || !target.isAlive()) {
+            remove();
         }
     }
 

--- a/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
+++ b/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
@@ -69,7 +69,7 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
     public void tick() {
         super.tick();
         if (target == null && getOwner() instanceof LivingEntity) {
-            target = getTarget(world.random, findNearbyPotentialTargets(world, getOwner()), getTargetOf((LivingEntity) getOwner()));
+            target = getTarget(world.random, findNearbyPotentialTargets(world, getOwner(), this), getTargetOf((LivingEntity) getOwner()));
         }
 
         if (target != null && target.isAlive()) {
@@ -139,8 +139,8 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
         return target;
     }
 
-    public static List<Entity> findNearbyPotentialTargets(World world, Entity owner) {
-        return world.getOtherEntities(owner, owner.getBoundingBox().expand(20.0), entity -> isValidTarget(entity, owner));
+    public static List<Entity> findNearbyPotentialTargets(World world, Entity owner, Entity lookFrom) {
+        return world.getOtherEntities(owner, lookFrom.getBoundingBox().expand(20.0), entity -> isValidTarget(entity, owner));
     }
 
     private static boolean isValidTarget(Entity entity, Entity owner) {

--- a/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
+++ b/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
@@ -84,7 +84,7 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
         }
         if (world.isClient) {
             world.addParticle(new DustParticleEffect(0.0f, 1.0f, 0.0f, 1.0f), getX(), getY(), getZ(), 0.0, 0.0, 0.0);
-        } else if (inGround || (target != null && !target.isAlive())) {
+        } else if (inGround || (target != null && !target.isAlive()) || (target == null && getVelocity().lengthSquared() <= 0.04)) {
             remove();
         }
     }

--- a/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
+++ b/src/main/java/mrsterner/phantomblood/common/entity/EmeraldSplashEntity.java
@@ -21,6 +21,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.network.Packet;
 import net.minecraft.particle.DustParticleEffect;
+import net.minecraft.sound.SoundEvent;
+import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.hit.EntityHitResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
@@ -48,6 +50,7 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
         this.target = target;
         setNoGravity(true);
         setPos(getX()+world.random.nextGaussian(), getY()+world.random.nextDouble(), getZ()+world.random.nextGaussian());
+        setSound(SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP);
         if (target == null) {
             setVelocity(owner.getRotationVector().normalize());
         }
@@ -106,6 +109,11 @@ public class EmeraldSplashEntity extends PersistentProjectileEntity implements F
     @Environment(EnvType.CLIENT)
     public ItemStack getStack() {
         return Items.EMERALD.getDefaultStack();
+    }
+
+    @Override
+    protected SoundEvent getHitSound() {
+        return SoundEvents.ENTITY_EXPERIENCE_ORB_PICKUP;
     }
 
     public static @Nullable Entity getTarget(Random random, List<Entity> nearbyPotentialTargets, @Nullable Entity playerTarget) {

--- a/src/main/java/mrsterner/phantomblood/common/stand/Stand.java
+++ b/src/main/java/mrsterner/phantomblood/common/stand/Stand.java
@@ -1,7 +1,6 @@
 package mrsterner.phantomblood.common.stand;
 
 
-import mrsterner.phantomblood.PhantomBlood;
 import mrsterner.phantomblood.common.entity.EmeraldSplashEntity;
 import mrsterner.phantomblood.common.entity.KillerVirusEntity;
 import mrsterner.phantomblood.common.registry.PBObjects;
@@ -10,17 +9,15 @@ import mrsterner.phantomblood.common.registry.PBStatusEffects;
 import mrsterner.phantomblood.common.timestop.TimeStopUtils;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.block.DispenserBlock;
-import net.minecraft.block.DropperBlock;
-import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
-import net.minecraft.item.BowItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.MathHelper;
 
+import java.util.List;
 import java.util.Locale;
 
 public enum Stand {
@@ -48,7 +45,7 @@ public enum Stand {
             long ticks = StandUtils.getStandLevel(player) == 0 ? 90 : 180;
             int energy = StandUtils.getStandEnergy(player);
             int energyForAbility = StandUtils.getStand(player).energyForAbility;
-             if (energy >= energyForAbility) {
+            if (energy >= energyForAbility) {
                 StandUtils.setStandEnergy(player, energy - energyForAbility);
                 TimeStopUtils.setTimeStoppedTicks(player.world, ticks);
                 TimeStopUtils.setTimeStopper(player.world, player);
@@ -106,8 +103,10 @@ public enum Stand {
             int energy = StandUtils.getStandEnergy(player);
             int energyForAbility = StandUtils.getStand(player).energyForAbility;
             if (energy >= energyForAbility) {
+                    List<Entity> nearbyPotentialTargets = EmeraldSplashEntity.findNearbyPotentialTargets(player.world, player);
+                    Entity playerTarget = EmeraldSplashEntity.getTargetOf(player);
                 for (int i = 0; i < 20; i++) {
-                    player.world.spawnEntity(new EmeraldSplashEntity(player, player.world.getOtherEntities(player, player.getBoundingBox().expand(20.0), p -> p instanceof LivingEntity).get(0), player.world));
+                    player.world.spawnEntity(new EmeraldSplashEntity(player, EmeraldSplashEntity.getTarget(player.world.random, nearbyPotentialTargets, playerTarget), player.world));
                 }
             }
         });

--- a/src/main/java/mrsterner/phantomblood/common/stand/Stand.java
+++ b/src/main/java/mrsterner/phantomblood/common/stand/Stand.java
@@ -102,12 +102,16 @@ public enum Stand {
         server.execute(() -> {
             int energy = StandUtils.getStandEnergy(player);
             int energyForAbility = StandUtils.getStand(player).energyForAbility;
+
             if (energy >= energyForAbility) {
-                    List<Entity> nearbyPotentialTargets = EmeraldSplashEntity.findNearbyPotentialTargets(player.world, player);
-                    Entity playerTarget = EmeraldSplashEntity.getTargetOf(player);
+                List<Entity> nearbyPotentialTargets = EmeraldSplashEntity.findNearbyPotentialTargets(player.world, player, player);
+                Entity playerTarget = EmeraldSplashEntity.getTargetOf(player);
+
                 for (int i = 0; i < 20; i++) {
                     player.world.spawnEntity(new EmeraldSplashEntity(player, EmeraldSplashEntity.getTarget(player.world.random, nearbyPotentialTargets, playerTarget), player.world));
                 }
+
+                StandUtils.setStandEnergy(player, energy-energyForAbility);
             }
         });
     }),

--- a/src/main/java/mrsterner/phantomblood/common/stand/Stand.java
+++ b/src/main/java/mrsterner/phantomblood/common/stand/Stand.java
@@ -2,6 +2,7 @@ package mrsterner.phantomblood.common.stand;
 
 
 import mrsterner.phantomblood.PhantomBlood;
+import mrsterner.phantomblood.common.entity.EmeraldSplashEntity;
 import mrsterner.phantomblood.common.entity.KillerVirusEntity;
 import mrsterner.phantomblood.common.registry.PBObjects;
 import mrsterner.phantomblood.common.registry.PBSoundEvents;
@@ -11,6 +12,7 @@ import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.block.DropperBlock;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.item.BowItem;
@@ -99,7 +101,15 @@ public enum Stand {
         });
     }),
     TWENTY_CENTURY_BOY(30000, (server, player, handler1, buf, responseSender) -> {}),
-    HIEROPHANT_GREEN(3000, (server, player, handler1, buf, responseSender) -> {}),
+    HIEROPHANT_GREEN(3000, (server, player, handler1, buf, responseSender) -> {
+        server.execute(() -> {
+            int energy = StandUtils.getStandEnergy(player);
+            int energyForAbility = StandUtils.getStand(player).energyForAbility;
+            if (energy >= energyForAbility) {
+                player.world.spawnEntity(new EmeraldSplashEntity(player, player.world.getOtherEntities(player, player.getBoundingBox().expand(20.0), p -> p instanceof LivingEntity).get(0), player.world));
+            }
+        });
+    }),
     ANUBIS(3000, (server, player, handler1, buf, responseSender) -> {});
 
     public int energyForAbility;

--- a/src/main/java/mrsterner/phantomblood/common/stand/Stand.java
+++ b/src/main/java/mrsterner/phantomblood/common/stand/Stand.java
@@ -106,7 +106,9 @@ public enum Stand {
             int energy = StandUtils.getStandEnergy(player);
             int energyForAbility = StandUtils.getStand(player).energyForAbility;
             if (energy >= energyForAbility) {
-                player.world.spawnEntity(new EmeraldSplashEntity(player, player.world.getOtherEntities(player, player.getBoundingBox().expand(20.0), p -> p instanceof LivingEntity).get(0), player.world));
+                for (int i = 0; i < 20; i++) {
+                    player.world.spawnEntity(new EmeraldSplashEntity(player, player.world.getOtherEntities(player, player.getBoundingBox().expand(20.0), p -> p instanceof LivingEntity).get(0), player.world));
+                }
             }
         });
     }),


### PR DESCRIPTION
This PR adds Hierophant Green's Emerald Splash power.

# Demonstration

It is demonstrated with three videos:

## Demonstration 1

This demonstration shows how the emerald splash chooses targets. As it spawns, it has a 50-50 chance of either targeting the player's current combat target, or a random nearby potential target.

![Demo 1](https://cdn.discordapp.com/attachments/665281306426474506/905568911674708039/demo1.webm)

## Demonstration 2

This demonstration shows how the emerald splash maneuvers to targets and how it can be blocked. It can turn corners and change trajectory quickly, however it can be blocked by placing blocks in its way.

![Demo 2](https://cdn.discordapp.com/attachments/665281306426474506/905571077449740318/demo2.webm)

## Demonstration 3

This demonstration shows how the emerald splash interacts with neutral mobs, and what it does when there's no target.

When there's no target available, the emerald splash simply moves forwards. If, during its flight, it sees a potential target within 20 blocks, it will fly towards it.

Neutral mobs are not seen as targets until they are angered.

![Demo 3](https://cdn.discordapp.com/attachments/665281306426474506/905571704070344704/demo3.webm)
